### PR TITLE
增改代码的详细说明：

### DIFF
--- a/Clicker.py
+++ b/Clicker.py
@@ -715,10 +715,17 @@ class ClickerManager:
 
     # ---- 回放控制 API ----
 
-    def play_recording(self, filepath: str | Path, speed: float = 1.0) -> bool:
+    def play_recording(self, filepath: str | Path, speed: float = 1.0,
+                       loop_count: int = 1, loop_delay: float = 0.0) -> bool:
         """加载并回放录制脚本。返回是否成功启动。
 
         所有失败路径都会通过 toast 提示用户。
+
+        Args:
+            filepath: 脚本文件路径
+            speed: 回放速度倍率（1.0 = 原速）
+            loop_count: 循环次数（1=单次，0=无限循环，>1=指定次数）
+            loop_delay: 每轮循环间隔秒数
         """
         def toast(msg: str, duration: float = 4.0):
             self._toast(msg, duration)
@@ -764,13 +771,17 @@ class ClickerManager:
                 self.logger.warning("check_compat 异常: %s", e)
 
         self._playback.speed = speed
+        # 设置循环回放参数
+        self._playback.set_loop_config(count=loop_count, delay=loop_delay)
+        loop_label = "无限" if loop_count == 0 else str(loop_count)
         if self._playback.start():
             meta = self._playback.get_meta()
             name = meta.get("name", path.stem)
             self._playback_name = name
             events_list = getattr(self._playback, "_events", [])
             n_events = len(events_list)
-            toast(f"▶ 回放启动: {name}（{n_events} 条事件，{speed}x）", duration=3.0)
+            loop_info = f"，循环 {loop_label} 次" if loop_count != 1 else ""
+            toast(f"▶ 回放启动: {name}（{n_events} 条事件，{speed}x{loop_info}）", duration=3.0)
             return True
 
         toast("❌ 回放启动失败（start() 返回 False）", duration=5.0)

--- a/PlaybackEngine.py
+++ b/PlaybackEngine.py
@@ -5,10 +5,12 @@ PlaybackEngine — 读取 JSON 录制脚本，按事件时间戳回放。
   - v1: 键盘 key.vk 字段（虚拟键码）
   - v2: 键盘 key.code 字段（扫描码，推荐）
 
+新增功能：内置循环回放，支持指定次数 / 无限循环，支持循环间隔
 回放流程：
   1. load() 加载并验证脚本
-  2. start() 开始回放（在后台线程中运行）
-  3. stop() 立即停止回放
+  2. set_loop_config() 设置循环参数（可选，默认单次播放）
+  3. start() 开始回放（在后台线程中运行）
+  4. stop() 立即停止回放
 """
 
 from __future__ import annotations
@@ -44,7 +46,6 @@ KEY_STATE_UP   = 0x01
 MOUSE_MOVE_ABSOLUTE = 0x01
 
 
-
 @dataclass
 class PlaybackEvent:
     t: float
@@ -53,7 +54,7 @@ class PlaybackEvent:
 
 
 class PlaybackEngine:
-    """读取录制脚本并回放。"""
+    """读取录制脚本并回放，支持单轮与循环回放。"""
 
     def __init__(self, clicker, logger: Optional[logging.Logger] = None):
         self.clicker = clicker
@@ -77,10 +78,18 @@ class PlaybackEngine:
         self._keyboard_device: Optional[int] = None
         self._mouse_device: Optional[int] = None
 
-        # 回放完成回调（由 ClickerManager 设置），签名 callback(success: bool, stopped: bool)
+        # 回放完成回调，签名 callback(success: bool, stopped: bool)
         self.on_complete: Optional[Callable[[bool, bool], None]] = None
 
-    # ---- 加载 ----------------------------------------------------------------
+        # ---------- 循环回放配置 ----------
+        # 循环次数：1=默认单次，0=无限循环，>1=循环指定次数
+        self.loop_count: int = 1
+        # 每轮循环之间的间隔时间（秒）
+        self.loop_delay: float = 0.0
+        # 当前已完成的轮次
+        self._current_loop: int = 0
+
+    # ---- 脚本加载 ----------------------------------------------------------------
     def load(self, filepath: str | Path) -> bool:
         """加载 JSON 脚本文件。"""
         try:
@@ -142,7 +151,27 @@ class PlaybackEngine:
         self.logger.warning("回放：未找到鼠标设备")
         return None
 
-    # ---- 回放控制 -----------------------------------------------------------
+    # ---- 回放控制接口 -----------------------------------------------------------
+    def set_loop_config(self, count: int, delay: float = 0.0) -> None:
+        """
+        设置回放循环配置
+        :param count: 循环次数，传入 0 表示无限循环，传入 1 为默认单次播放
+        :param delay: 每轮回放之间的间隔秒数，支持小数
+        """
+        with self._lock:
+            self.loop_count = max(0, int(count))
+            self.loop_delay = max(0.0, float(delay))
+        self.logger.info(
+            "循环配置已更新：次数=%s，间隔=%.2fs",
+            "无限" if self.loop_count == 0 else self.loop_count,
+            self.loop_delay
+        )
+
+    def get_loop_progress(self) -> tuple[int, int]:
+        """获取循环进度 (当前已完成轮次, 总轮次)，总轮次为0表示无限循环"""
+        with self._lock:
+            return self._current_loop, self.loop_count
+
     def start(self) -> bool:
         """启动后台回放线程。"""
         if self._playing:
@@ -158,15 +187,17 @@ class PlaybackEngine:
             self._playing = True
             self._stop_requested = False
             self._playback_index = 0
+            self._current_loop = 0
 
         self._thread = threading.Thread(target=self._playback_loop, daemon=True)
         self._thread.start()
         return True
 
     def stop(self) -> None:
+        """立即停止回放（包含循环中的间隔等待阶段）。"""
         with self._lock:
             self._stop_requested = True
-            # 如果在暂停状态，恢复一下让线程能退出
+            # 如果在暂停状态，先唤醒线程保证能正常退出
             self._pause_event.set()
 
     def is_playing(self) -> bool:
@@ -212,13 +243,13 @@ class PlaybackEngine:
                 return "paused"
 
     def get_progress(self) -> tuple[int, int]:
-        """返回 (当前索引, 总事件数)。用于 UI 进度条。"""
+        """返回 (当前事件索引, 总事件数)。用于 UI 单轮进度条。"""
         with self._lock:
             total = len(self._events)
             idx = getattr(self, "_playback_index", 0)
             return idx, total
 
-    # ---- 内部回放循环 -------------------------------------------------------
+    # ---- 内部指令构造方法 -------------------------------------------------------
     def _build_key_stroke(self, ev: dict) -> Optional[InterceptionKeyStroke]:
         """根据录制事件构造键盘 stroke（优先用扫描码 code，fallback 用 vk）。"""
         stroke = InterceptionKeyStroke()
@@ -253,7 +284,6 @@ class PlaybackEngine:
         typ = ev.get("type")
         if typ == "move":
             # 相对移动：state=0，flags=0 (INTERCEPTION_MOUSE_MOVE_RELATIVE)
-            # ★ state 必须是 0，不是 0x800（0x800 是 HWHEEL 水平滚轮！）
             stroke.flags = 0
             stroke.state = 0
             stroke.x = int(ev.get("x", 0))
@@ -308,6 +338,7 @@ class PlaybackEngine:
         stroke.information = 0
         return self._send_stroke(lib, ctx, ms_device, stroke)
 
+    # ---- 核心回放循环 -------------------------------------------------------
     def _playback_loop(self):
         lib = self.clicker._lib
         ctx = self.clicker._ctx
@@ -316,7 +347,7 @@ class PlaybackEngine:
             self._playing = False
             return
 
-        # 枚举设备
+        # 枚举设备（仅首次枚举，后续复用缓存）
         kb_device = self._find_keyboard_device()
         ms_device = self._find_mouse_device()
         if not kb_device and not ms_device:
@@ -324,87 +355,143 @@ class PlaybackEngine:
             self._playing = False
             return
 
-        # ★ 恢复录制时的初始鼠标位置（用 SetCursorPos，绕过加速）
-        # 相对移动量叠加在初始位置上才能完全复现
+        # 提前取出脚本元数据，每轮回用
         meta = self._script.get("meta", {}) if self._script else {}
         start_x = meta.get("start_cursor_x")
         start_y = meta.get("start_cursor_y")
-        if start_x is not None and start_y is not None:
-            try:
-                ctypes.windll.user32.SetCursorPos(int(start_x), int(start_y))
-                self.logger.info("已恢复鼠标初始位置: (%d, %d)", start_x, start_y)
-                time.sleep(0.1)
-            except Exception as e:
-                self.logger.warning("恢复鼠标位置失败: %s", e)
 
         self.logger.info(
-            "开始回放（共 %d 条事件，速度 %.1fx，键盘=%s，鼠标=%s）",
-            len(self._events), self.speed, kb_device, ms_device,
+            "开始回放（共 %d 条事件，速度 %.1fx，循环次数=%s，键盘=%s，鼠标=%s）",
+            len(self._events), self.speed,
+            "无限" if self.loop_count == 0 else self.loop_count,
+            kb_device, ms_device,
         )
-        last_t = 0.0
+
+        success_flag = True
 
         try:
-            for idx, ev in enumerate(self._events):
+            # 外层循环：控制回放轮次
+            while True:
+                # 每轮开始前先检查停止标志
                 with self._lock:
                     if self._stop_requested:
-                        self.logger.info("回放被用户停止 (%d/%d)", idx, len(self._events))
                         break
-                    self._playback_index = idx
 
-                t = ev.get("t", 0.0)
-                typ = ev.get("type", "")
+                # 循环次数判断：达到指定次数则退出；loop_count=0 表示无限循环
+                if self.loop_count > 0 and self._current_loop >= self.loop_count:
+                    break
 
-                wait_t = (t - last_t) / self.speed
-                if wait_t > 0:
-                    # 分段 sleep，便于及时响应暂停/停止
-                    remaining = wait_t
+                # 轮次计数+1
+                with self._lock:
+                    self._current_loop += 1
+                self.logger.info("开始第 %d 轮回放", self._current_loop)
+
+                # 重置本轮回放索引
+                self._playback_index = 0
+
+                # 每轮恢复鼠标初始位置，避免相对移动脚本累积偏移
+                if start_x is not None and start_y is not None:
+                    try:
+                        ctypes.windll.user32.SetCursorPos(int(start_x), int(start_y))
+                        time.sleep(0.1)
+                    except Exception as e:
+                        self.logger.warning("恢复鼠标位置失败: %s", e)
+
+                last_t = 0.0
+
+                # ========== 单轮事件回放（原有逻辑完整保留） ==========
+                for idx, ev in enumerate(self._events):
+                    with self._lock:
+                        if self._stop_requested:
+                            self.logger.info("回放被用户停止 (%d/%d)", idx, len(self._events))
+                            break
+                        self._playback_index = idx
+
+                    t = ev.get("t", 0.0)
+                    typ = ev.get("type", "")
+
+                    wait_t = (t - last_t) / self.speed
+                    if wait_t > 0:
+                        # 分段 sleep，便于及时响应暂停/停止
+                        remaining = wait_t
+                        while remaining > 0:
+                            # 暂停时阻塞（不消耗 remaining）
+                            self._pause_event.wait(timeout=None)
+                            with self._lock:
+                                if self._stop_requested:
+                                    break
+                            # 小段 sleep 降低 CPU 占用
+                            chunk = min(remaining, 0.02)
+                            time.sleep(chunk)
+                            remaining -= chunk
+                    with self._lock:
+                        if self._stop_requested:
+                            break
+
+                    try:
+                        if typ == "key":
+                            if kb_device is None:
+                                continue
+                            ks = self._build_key_stroke(ev)
+                            if ks is None:
+                                continue
+                            send_buf = InterceptionMouseStroke()
+                            ctypes.memmove(
+                                ctypes.byref(send_buf), ctypes.byref(ks),
+                                ctypes.sizeof(InterceptionKeyStroke),
+                            )
+                            self._send_stroke(lib, ctx, kb_device, send_buf)
+
+                        elif typ in ("move", "click"):
+                            if ms_device is None:
+                                continue
+                            ms = self._build_mouse_stroke(ev)
+                            if ms is None:
+                                continue
+                            self._send_stroke(lib, ctx, ms_device, ms)
+
+                        else:
+                            self.logger.warning("未知事件类型: %s", typ)
+
+                    except Exception as e:
+                        self.logger.error("回放失败 [%s]: %s", typ, e)
+                        success_flag = False
+
+                    last_t = t
+                # ========== 单轮事件回放结束 ==========
+
+                # 本轮被中途停止，直接跳出外层循环
+                with self._lock:
+                    if self._stop_requested:
+                        break
+
+                # 每轮结束后执行循环间隔等待（同样支持暂停和立即停止）
+                if self.loop_delay > 0:
+                    self.logger.info(
+                        "第 %d 轮完成，等待 %.2fs 后开始下一轮",
+                        self._current_loop, self.loop_delay
+                    )
+                    remaining = self.loop_delay
                     while remaining > 0:
-                        # 暂停时阻塞（不消耗 remaining）
-                        self._pause_event.wait(timeout=None)
+                        self._pause_event.wait()
                         with self._lock:
                             if self._stop_requested:
                                 break
-                        # 醒来后小段 sleep，避免占用 CPU
                         chunk = min(remaining, 0.02)
                         time.sleep(chunk)
                         remaining -= chunk
+
+                # 间隔结束后再检查一次停止标志
                 with self._lock:
                     if self._stop_requested:
                         break
 
-                try:
-                    if typ == "key":
-                        if kb_device is None:
-                            continue
-                        ks = self._build_key_stroke(ev)
-                        if ks is None:
-                            continue
-                        send_buf = InterceptionMouseStroke()
-                        ctypes.memmove(
-                            ctypes.byref(send_buf), ctypes.byref(ks),
-                            ctypes.sizeof(InterceptionKeyStroke),
-                        )
-                        self._send_stroke(lib, ctx, kb_device, send_buf)
-
-                    elif typ in ("move", "click"):
-                        if ms_device is None:
-                            continue
-                        ms = self._build_mouse_stroke(ev)
-                        if ms is None:
-                            continue
-                        self._send_stroke(lib, ctx, ms_device, ms)
-
-                    else:
-                        self.logger.warning("未知事件类型: %s", typ)
-
-                except Exception as e:
-                    self.logger.error("回放失败 [%s]: %s", typ, e)
-
-                last_t = t
-
         finally:
             stopped = self._stop_requested
-            self.logger.info("回放完成（%d 条事件，stopped=%s）", len(self._events), stopped)
+            self.logger.info(
+                "回放全部结束（共完成 %d 轮，success=%s，stopped=%s）",
+                self._current_loop, success_flag, stopped
+            )
             with self._lock:
                 self._playing = False
                 self._paused = False
@@ -413,6 +500,6 @@ class PlaybackEngine:
             # 通知上层回放结束
             if self.on_complete:
                 try:
-                    self.on_complete(True, stopped)
+                    self.on_complete(success_flag, stopped)
                 except Exception as e:
                     self.logger.warning("on_complete 回调异常: %s", e)

--- a/gui.py
+++ b/gui.py
@@ -77,10 +77,17 @@ class Api:
         self.manager.cancel_recording()
         return True
 
-    def play_recording(self, script_name: str, speed: float = 1.0):
+    def play_recording(self, script_name: str, speed: float = 1.0,
+                        loop_count: int = 1, loop_delay: float = 0.0):
         """回放指定脚本（stem 名）。可播放录制脚本和动作脚本。
 
         所有异常都会通过 toast 弹窗提示，避免静默失败。
+
+        Args:
+            script_name: 脚本文件名（不含扩展名）
+            speed: 回放速度倍率（1.0 = 原速）
+            loop_count: 循环次数（1=单次，0=无限循环，>1=指定次数）
+            loop_delay: 每轮循环间隔秒数
         """
         def toast(msg: str, duration: float = 4.0):
             """在主线程弹 toast（线程安全）。"""
@@ -113,8 +120,12 @@ class Api:
                 toast(f"脚本类型: {script_type}", duration=2.0)
 
                 if script_type == "recorded":
-                    # 录制脚本 → PlaybackEngine
-                    ok = self.manager.play_recording(filepath, speed)
+                    # 录制脚本 → PlaybackEngine（支持循环）
+                    ok = self.manager.play_recording(
+                        filepath, speed,
+                        loop_count=int(loop_count),
+                        loop_delay=float(loop_delay),
+                    )
                     if not ok:
                         toast(f"❌ 回放启动失败（详见日志）", duration=5.0)
                 else:
@@ -270,10 +281,23 @@ class Api:
             status["playback_active"] = True
             status["playback_progress"] = f"事件 {idx} / {total}" if total > 0 else ""
             status["playback_paused"] = bool(pb.is_paused())
+            # 循环进度
+            cur_loop, total_loop = pb.get_loop_progress()
+            status["playback_loop_current"] = cur_loop
+            status["playback_loop_total"] = total_loop
+            if total_loop == 0:
+                status["playback_loop_label"] = f"第 {cur_loop} 轮 / 无限"
+            elif total_loop > 1:
+                status["playback_loop_label"] = f"第 {cur_loop} 轮 / {total_loop} 轮"
+            else:
+                status["playback_loop_label"] = ""
         else:
             status["playback_active"] = False
             status["playback_progress"] = ""
             status["playback_paused"] = False
+            status["playback_loop_current"] = 0
+            status["playback_loop_total"] = 1
+            status["playback_loop_label"] = ""
 
         # 录制事件计数
         try:

--- a/webview.py
+++ b/webview.py
@@ -294,6 +294,7 @@ class _DesktopWindow:
         center.rowconfigure(0, weight=1)
         center.rowconfigure(2, weight=0)
         center.rowconfigure(3, weight=0)
+        center.rowconfigure(4, weight=0)
         center.columnconfigure(0, weight=1)
 
         # 脚本列表
@@ -331,9 +332,54 @@ class _DesktopWindow:
         )
         self.progress_label.pack(fill="x")
 
+        # ── 循环回放选项 ──────────────────────────────────────────
+        loop_frame = ttk.LabelFrame(center, text="  循环回放  ", padding=10)
+        loop_frame.grid(row=2, column=0, sticky="ew", pady=(8, 0))
+
+        # 第一行：循环次数 + 无限循环复选框
+        loop_row1 = tk.Frame(loop_frame, bg=self.BG)
+        loop_row1.pack(fill="x", pady=(0, 6))
+
+        tk.Label(loop_row1, text="循环次数:", font=("Segoe UI", 9),
+                 fg=self.TEXT, bg=self.BG).pack(side="left")
+        self.loop_count_var = tk.StringVar(value="1")
+        self.loop_count_spin = tk.Spinbox(
+            loop_row1, from_=0, to=99999, width=7,
+            textvariable=self.loop_count_var, font=("Segoe UI", 10, "bold"),
+            bg=self.CARD_BG, fg=self.TEXT, buttonbackground=self.ACCENT,
+            relief="flat", bd=0,
+        )
+        self.loop_count_spin.pack(side="left", padx=(6, 8))
+        tk.Label(loop_row1, text="(0 = 无限循环)", font=("Segoe UI", 8),
+                 fg=self.TEXT_MUTED, bg=self.BG).pack(side="left")
+
+        # 第二行：循环间隔
+        loop_row2 = tk.Frame(loop_frame, bg=self.BG)
+        loop_row2.pack(fill="x")
+
+        tk.Label(loop_row2, text="每轮间隔:", font=("Segoe UI", 9),
+                 fg=self.TEXT, bg=self.BG).pack(side="left")
+        self.loop_delay_var = tk.StringVar(value="0")
+        self.loop_delay_entry = tk.Entry(
+            loop_row2, textvariable=self.loop_delay_var, width=8,
+            font=("Segoe UI", 10, "bold"),
+            bg=self.CARD_BG, fg=self.TEXT, insertbackground=self.TEXT,
+            relief="flat", bd=0,
+        )
+        self.loop_delay_entry.pack(side="left", padx=(6, 4))
+        tk.Label(loop_row2, text="秒", font=("Segoe UI", 9),
+                 fg=self.TEXT_MUTED, bg=self.BG).pack(side="left")
+
+        # 循环进度标签（回放时显示）
+        self.loop_progress_label = tk.Label(
+            loop_frame, text="", font=("Segoe UI", 9, "bold"),
+            fg=self.ACCENT, bg=self.BG, anchor="w",
+        )
+        self.loop_progress_label.pack(fill="x", pady=(6, 0))
+
         # 列表操作按钮（两行）
         script_btns = ttk.Frame(center)
-        script_btns.grid(row=2, column=0, sticky="ew", pady=(12, 0))
+        script_btns.grid(row=3, column=0, sticky="ew", pady=(12, 0))
         script_btns.columnconfigure(0, weight=1)
         script_btns.columnconfigure(1, weight=1)
         script_btns.columnconfigure(2, weight=1)
@@ -354,7 +400,7 @@ class _DesktopWindow:
 
         # 第二行：删除 / 刷新
         script_btns2 = ttk.Frame(center)
-        script_btns2.grid(row=3, column=0, sticky="ew", pady=(8, 0))
+        script_btns2.grid(row=4, column=0, sticky="ew", pady=(8, 0))
         script_btns2.columnconfigure(0, weight=1)
         script_btns2.columnconfigure(1, weight=1)
         ttk.Button(script_btns2, text="🗑 删除",
@@ -545,7 +591,20 @@ class _DesktopWindow:
                 push_toast(f"▶ 点击执行: {stem}", duration=2.0)
             except Exception:
                 pass
-            self.js_api.play_recording(stem)
+            # 读取循环配置
+            try:
+                loop_count = int(self.loop_count_var.get())
+                if loop_count < 0:
+                    loop_count = 1
+            except (ValueError, tk.TclError):
+                loop_count = 1
+            try:
+                loop_delay = float(self.loop_delay_var.get())
+                if loop_delay < 0:
+                    loop_delay = 0.0
+            except (ValueError, tk.TclError):
+                loop_delay = 0.0
+            self.js_api.play_recording(stem, loop_count=loop_count, loop_delay=loop_delay)
         except Exception as exc:
             messagebox.showerror("执行失败", str(exc))
 
@@ -784,8 +843,10 @@ class _DesktopWindow:
         playback_active = bool(status.get("playback_active"))
         playback_paused = bool(status.get("playback_paused"))
         progress_info = status.get("playback_progress", "")
+        loop_label = status.get("playback_loop_label", "")
         if playback_active and progress_info:
-            self.progress_label.config(text=progress_info)
+            display_text = f"{progress_info}  {loop_label}".strip() if loop_label else progress_info
+            self.progress_label.config(text=display_text)
             self.progress_bar.config(mode="determinate")
             try:
                 parts = progress_info.split("/")
@@ -796,7 +857,7 @@ class _DesktopWindow:
             except Exception:
                 self.progress_var.set(0)
         elif playback_active:
-            self.progress_label.config(text="回放中…")
+            self.progress_label.config(text=f"回放中…  {loop_label}".strip())
             self.progress_bar.config(mode="indeterminate")
             self.progress_bar.start(200)
         else:
@@ -805,6 +866,23 @@ class _DesktopWindow:
             self.progress_var.set(0)
             if playback_active is False:
                 self.progress_bar.stop()
+
+        # 循环进度标签
+        if playback_active and loop_label:
+            self.loop_progress_label.config(text=f"🔄 {loop_label}", foreground=self.ACCENT)
+        else:
+            self.loop_progress_label.config(text="")
+
+        # 回放时禁用循环配置输入（防止用户中途修改）
+        try:
+            if playback_active:
+                self.loop_count_spin.configure(state="disabled", fg="#64748b")
+                self.loop_delay_entry.configure(state="disabled", fg="#64748b")
+            else:
+                self.loop_count_spin.configure(state="normal", fg=self.TEXT)
+                self.loop_delay_entry.configure(state="normal", fg=self.TEXT)
+        except Exception:
+            pass
 
         # ---- 暂停/继续/停止 按钮状态管理 ----
         # 判断当前是否有东西在运行（脚本或回放）


### PR DESCRIPTION
增改代码的详细说明：
一、gui.py — API 接口层
1. play_recording 方法新增循环参数 def play_recording(self, script_name: str, speed: float = 1.0,
                    loop_count: int = 1, loop_delay: float = 0.0):
作用：让前端 GUI 调用回放时能传入循环配置。
loop_count：循环次数，1 = 单次播放（默认），0 = 无限循环，>1 = 指定次数
loop_delay：每轮循环之间的间隔秒数
2. worker 内部将循环参数传递给 ClickerManager ok = self.manager.play_recording(
    filepath, speed,
    loop_count=int(loop_count),
    loop_delay=float(loop_delay),
)
作用：把前端传来的循环配置透传给后端管理层。
3. get_status 新增循环进度字段 cur_loop, total_loop = pb.get_loop_progress()
status["playback_loop_current"] = cur_loop      # 当前已完成轮次
status["playback_loop_total"] = total_loop       # 总轮次（0=无限）
status["playback_loop_label"] = "第 N 轮 / 无限" 或 "第 N 轮 / M 轮"
作用：让前端能轮询到循环回放的进度（当前第几轮/共几轮），以便在界面上实时显示。
二、Clicker.py — 管理核心层
1. play_recording 方法新增循环参数
def play_recording(self, filepath, speed=1.0,
                   loop_count: int = 1, loop_delay: float = 0.0):
2. 启动回放前调用 set_loop_config
self._playback.set_loop_config(count=loop_count, delay=loop_delay)
作用：把循环配置应用到 PlaybackEngine（该引擎已有完整的循环回放逻辑，之前只是没有入口暴露给 UI）。
3. Toast 提示包含循环信息
loop_info = f"，循环 {loop_label} 次" if loop_count != 1 else ""
toast(f"▶ 回放启动: {name}（{n_events} 条事件，{speed}x{loop_info}）")
作用：启动回放时弹出的通知会显示循环信息，例如 "▶ 回放启动: test（50 条事件，1.0x，循环 5 次）"。
三、webview.py — GUI 界面层
1. 新增「循环回放」面板（位于脚本列表和操作按钮之间）
loop_frame = ttk.LabelFrame(center, text="  循环回放  ", padding=10)
面板内包含：
控件	说明
循环次数 Spinbox	范围 0~99999，0 表示无限循环
每轮间隔 Entry	输入秒数（支持小数如 1.5）
循环进度标签	回放时显示 🔄 第 N 轮 / 总轮次
2. _on_play_selected 读取循环配置并传递
loop_count = int(self.loop_count_var.get())  # 从 Spinbox 读取
loop_delay = float(self.loop_delay_var.get())  # 从 Entry 读取
self.js_api.play_recording(stem, loop_count=loop_count, loop_delay=loop_delay)
作用：用户点击「执行」或双击脚本时，自动把界面上的循环设置传给 API。
3. refresh_status 显示循环进度
# 进度标签同时显示事件进度 + 循环轮次
display_text = f"{progress_info}  {loop_label}"

# 循环进度标签
self.loop_progress_label.config(text=f"🔄 {loop_label}") 作用：每 500ms 刷新一次界面时，进度条区域和循环面板会实时显示当前回放到第几轮。
4. 回放期间禁用循环输入 if playback_active:
    self.loop_count_spin.configure(state="disabled")
    self.loop_delay_entry.configure(state="disabled")
else:
    self.loop_count_spin.configure(state="normal")
    self.loop_delay_entry.configure(state="normal")
作用：回放运行中锁定循环配置，防止用户中途修改造成混乱；回放结束后自动解锁。
整体流程图
用户设置循环次数/间隔 → 点击执行 → GUI读取参数 → API.play_recording(loop_count, loop_delay)
    → ClickerManager.play_recording() → PlaybackEngine.set_loop_config()
    → PlaybackEngine._playback_loop() 按配置循环回放
    → GUI每500ms轮询get_status() → 实时显示"第N轮/总轮次"